### PR TITLE
Test Case 2: MockConnection createChannel returns valid MockChannel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <assertj.version>3.27.3</assertj.version>
         <mockito.version>5.15.2</mockito.version>
         <micrometer.version>1.14.3</micrometer.version>
-        <spring-rabbit.version>3.2.1</spring-rabbit.version>
+        <spring-rabbit.version>3.2.2</spring-rabbit.version>
         <logback.version>1.5.16</logback.version>
 
         <skipTests>false</skipTests>

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTestCase1.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTestCase1.java
@@ -1,0 +1,13 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockConnectionFactoryTestCase1 {
+
+    @Test
+    void newConnection_shouldReturnNonNullConnection() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        assertNotNull(factory.newConnection(), "Connection should not be null");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase2.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase2.java
@@ -1,0 +1,20 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockConnectionTestCase2 {
+
+    @Test
+    void createChannel_shouldReturnValidMockChannel() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        assertNotNull(connection, "Connection should not be null");
+
+        MockChannel channel = (MockChannel) connection.createChannel();
+        assertNotNull(channel, "Channel should not be null");
+        assertTrue(channel instanceof MockChannel, "Should be instance of MockChannel");
+    }
+}
+


### PR DESCRIPTION
Test Target: MockConnection  
What is being tested: Verifies that `createChannel()` returns a non-null `MockChannel` instance  
Technique Used: Equivalence Partitioning  
Expected Result: Non-null `MockChannel` object returned from `createChannel()`  
**Actual Result: Test passed successfully — valid `MockChannel` instance was returned**

