### PR TITLE
Test case 4: BasicPublish handles empty and large messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <assertj.version>3.27.3</assertj.version>
         <mockito.version>5.15.2</mockito.version>
         <micrometer.version>1.14.3</micrometer.version>
-        <spring-rabbit.version>3.2.1</spring-rabbit.version>
+        <spring-rabbit.version>3.2.2</spring-rabbit.version>
         <logback.version>1.5.16</logback.version>
 
         <skipTests>false</skipTests>

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
@@ -718,6 +718,10 @@ public class MockChannel implements Channel {
         return node.getQueue(queueName);
     }
 
+    public Object isQueueDeclared(String queueName) {
+        return null;
+    }
+
     private static class ReturnListenerAdapter implements ReturnListener {
         private final ReturnCallback callback;
 

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase3.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase3.java
@@ -1,0 +1,23 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase3 {
+
+    @Test
+    void queueDeclare_andBasicPublish_shouldSucceed() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "test-queue";
+        channel.queueDeclare(queueName, false, false, false, null);
+
+        // Try publishing a message to the queue
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, "Hello".getBytes());
+        }, "Should be able to publish to declared queue");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase4.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase4.java
@@ -1,0 +1,35 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase4 {
+
+    @Test
+    void basicPublish_shouldHandleEmptyAndLargeMessages() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "boundary-queue";
+        channel.queueDeclare(queueName, false, false, false, null);
+
+        // Test 1: Empty message
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, new byte[0]);
+        }, "Should handle empty message");
+
+        // Test 2: Large message (~1 MB)
+        byte[] largeMessage = new byte[1024 * 1024]; // 1 MB
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, largeMessage);
+        }, "Should handle large message (1MB)");
+
+        // Optional Test 3: Just below a "fake" upper limit (e.g., 1.5 MB)
+        byte[] almostTooLarge = new byte[1024 * 1024 + 512 * 1024]; // 1.5 MB
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, almostTooLarge);
+        }, "Should handle 1.5MB message (boundary)");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTestCase1.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTestCase1.java
@@ -1,0 +1,13 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockConnectionFactoryTestCase1 {
+
+    @Test
+    void newConnection_shouldReturnNonNullConnection() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        assertNotNull(factory.newConnection(), "Connection should not be null");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase2.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase2.java
@@ -1,0 +1,20 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockConnectionTestCase2 {
+
+    @Test
+    void createChannel_shouldReturnValidMockChannel() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        assertNotNull(connection, "Connection should not be null");
+
+        MockChannel channel = (MockChannel) connection.createChannel();
+        assertNotNull(channel, "Channel should not be null");
+        assertTrue(channel instanceof MockChannel, "Should be instance of MockChannel");
+    }
+}
+


### PR DESCRIPTION
Test Target: MockChannel

What is being tested: Verifies that basicPublish() handles different message sizes

Technique Used: Boundary Value Analysis

Expected Result: Empty and large messages are accepted without error

Actual Result: Test passed successfully — both empty and large messages were handled correctly without exceptions