### PR TITLE
Test case 7: Verify behavior of MockChannel after close operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <assertj.version>3.27.3</assertj.version>
         <mockito.version>5.15.2</mockito.version>
         <micrometer.version>1.14.3</micrometer.version>
-        <spring-rabbit.version>3.2.1</spring-rabbit.version>
+        <spring-rabbit.version>3.2.2</spring-rabbit.version>
         <logback.version>1.5.16</logback.version>
 
         <skipTests>false</skipTests>

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
@@ -718,6 +718,10 @@ public class MockChannel implements Channel {
         return node.getQueue(queueName);
     }
 
+    public Object isQueueDeclared(String queueName) {
+        return null;
+    }
+
     private static class ReturnListenerAdapter implements ReturnListener {
         private final ReturnCallback callback;
 

--- a/src/test/java/MockChannelTestCase5.java
+++ b/src/test/java/MockChannelTestCase5.java
@@ -1,0 +1,27 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase5 {
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, false, false",
+        "false, true, true",
+        "true, true, true"
+    })
+    void queueDeclare_withDifferentFlags_shouldSucceed(boolean durable, boolean exclusive, boolean autoDelete) throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "decision-queue-" + durable + "-" + exclusive + "-" + autoDelete;
+
+        assertDoesNotThrow(() -> {
+            channel.queueDeclare(queueName, durable, exclusive, autoDelete, null);
+        }, "Should successfully declare queue with flags: durable=" + durable + ", exclusive=" + exclusive + ", autoDelete=" + autoDelete);
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase3.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase3.java
@@ -1,0 +1,23 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase3 {
+
+    @Test
+    void queueDeclare_andBasicPublish_shouldSucceed() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "test-queue";
+        channel.queueDeclare(queueName, false, false, false, null);
+
+        // Try publishing a message to the queue
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, "Hello".getBytes());
+        }, "Should be able to publish to declared queue");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase4.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase4.java
@@ -1,0 +1,35 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase4 {
+
+    @Test
+    void basicPublish_shouldHandleEmptyAndLargeMessages() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "boundary-queue";
+        channel.queueDeclare(queueName, false, false, false, null);
+
+        // Test 1: Empty message
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, new byte[0]);
+        }, "Should handle empty message");
+
+        // Test 2: Large message (~1 MB)
+        byte[] largeMessage = new byte[1024 * 1024]; // 1 MB
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, largeMessage);
+        }, "Should handle large message (1MB)");
+
+        // Optional Test 3: Just below a "fake" upper limit (e.g., 1.5 MB)
+        byte[] almostTooLarge = new byte[1024 * 1024 + 512 * 1024]; // 1.5 MB
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, almostTooLarge);
+        }, "Should handle 1.5MB message (boundary)");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase7.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase7.java
@@ -1,0 +1,24 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase7 {
+
+    @Test
+    void usingChannelAfterClose_shouldNotThrowException() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "closed-channel-queue";
+        channel.queueDeclare(queueName, false, false, false, null);
+        channel.close();  // Closing the channel
+
+        // Behavior: mock allows use of closed channel
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, "Still working?".getBytes());
+        }, "Publishing after channel.close() should not throw (mock behavior)");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTestCase1.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTestCase1.java
@@ -1,0 +1,13 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockConnectionFactoryTestCase1 {
+
+    @Test
+    void newConnection_shouldReturnNonNullConnection() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        assertNotNull(factory.newConnection(), "Connection should not be null");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase2.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase2.java
@@ -1,0 +1,20 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockConnectionTestCase2 {
+
+    @Test
+    void createChannel_shouldReturnValidMockChannel() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        assertNotNull(connection, "Connection should not be null");
+
+        MockChannel channel = (MockChannel) connection.createChannel();
+        assertNotNull(channel, "Channel should not be null");
+        assertTrue(channel instanceof MockChannel, "Should be instance of MockChannel");
+    }
+}
+

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/mockChannelTestCase6.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/mockChannelTestCase6.java
@@ -1,0 +1,22 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class mockChannelTestCase6 {
+
+    @Test
+    void basicPublish_toUndeclaredQueue_shouldNotCrash() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "non-existent-queue";
+
+        // Assert that publishing to undeclared queue does not throw
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, "Silent publish".getBytes());
+        }, "Publishing to undeclared queue should not crash (mock behavior)");
+    }
+}


### PR DESCRIPTION
**Test Target:** MockChannel  
**What is being tested:** Behavior of using a channel after calling `.close()`  
**Technique Used:** State Transition Testing  
**Expected Result:** Publishing still succeeds after closing the channel (based on mock implementation)  
**Actual Result:** Test passed successfully — publishing was allowed after closing the channel, as per mock behavior.

