### PR TITLE
Test case 9: Re-declaring queue with conflicting flags should not fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <assertj.version>3.27.3</assertj.version>
         <mockito.version>5.15.2</mockito.version>
         <micrometer.version>1.14.3</micrometer.version>
-        <spring-rabbit.version>3.2.1</spring-rabbit.version>
+        <spring-rabbit.version>3.2.2</spring-rabbit.version>
         <logback.version>1.5.16</logback.version>
 
         <skipTests>false</skipTests>

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
@@ -718,6 +718,10 @@ public class MockChannel implements Channel {
         return node.getQueue(queueName);
     }
 
+    public Object isQueueDeclared(String queueName) {
+        return null;
+    }
+
     private static class ReturnListenerAdapter implements ReturnListener {
         private final ReturnCallback callback;
 

--- a/src/test/java/MockChannelTestCase5.java
+++ b/src/test/java/MockChannelTestCase5.java
@@ -1,0 +1,27 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase5 {
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, false, false",
+        "false, true, true",
+        "true, true, true"
+    })
+    void queueDeclare_withDifferentFlags_shouldSucceed(boolean durable, boolean exclusive, boolean autoDelete) throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "decision-queue-" + durable + "-" + exclusive + "-" + autoDelete;
+
+        assertDoesNotThrow(() -> {
+            channel.queueDeclare(queueName, durable, exclusive, autoDelete, null);
+        }, "Should successfully declare queue with flags: durable=" + durable + ", exclusive=" + exclusive + ", autoDelete=" + autoDelete);
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase3.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase3.java
@@ -1,0 +1,23 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase3 {
+
+    @Test
+    void queueDeclare_andBasicPublish_shouldSucceed() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "test-queue";
+        channel.queueDeclare(queueName, false, false, false, null);
+
+        // Try publishing a message to the queue
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, "Hello".getBytes());
+        }, "Should be able to publish to declared queue");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase4.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase4.java
@@ -1,0 +1,35 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase4 {
+
+    @Test
+    void basicPublish_shouldHandleEmptyAndLargeMessages() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "boundary-queue";
+        channel.queueDeclare(queueName, false, false, false, null);
+
+        // Test 1: Empty message
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, new byte[0]);
+        }, "Should handle empty message");
+
+        // Test 2: Large message (~1 MB)
+        byte[] largeMessage = new byte[1024 * 1024]; // 1 MB
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, largeMessage);
+        }, "Should handle large message (1MB)");
+
+        // Optional Test 3: Just below a "fake" upper limit (e.g., 1.5 MB)
+        byte[] almostTooLarge = new byte[1024 * 1024 + 512 * 1024]; // 1.5 MB
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, almostTooLarge);
+        }, "Should handle 1.5MB message (boundary)");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase7.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase7.java
@@ -1,0 +1,24 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase7 {
+
+    @Test
+    void usingChannelAfterClose_shouldNotThrowException() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "closed-channel-queue";
+        channel.queueDeclare(queueName, false, false, false, null);
+        channel.close();  // Closing the channel
+
+        // Behavior: mock allows use of closed channel
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, "Still working?".getBytes());
+        }, "Publishing after channel.close() should not throw (mock behavior)");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase9.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockChannelTestCase9.java
@@ -1,0 +1,26 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockChannelTestCase9 {
+
+    @Test
+    void reDeclareQueueWithDifferentFlags_shouldThrowOrPassSilently() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "conflicting-queue";
+
+        // Declare queue initially with durable=false
+        channel.queueDeclare(queueName, false, false, false, null);
+
+        // Now try to re-declare with different flags (durable=true)
+        // Some mocks may throw, others may ignore — we test & document
+        assertDoesNotThrow(() -> {
+            channel.queueDeclare(queueName, true, false, false, null);
+        }, "Re-declaring queue with conflicting durable flag should not throw (mock behavior)");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTestCase1.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTestCase1.java
@@ -1,0 +1,13 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockConnectionFactoryTestCase1 {
+
+    @Test
+    void newConnection_shouldReturnNonNullConnection() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        assertNotNull(factory.newConnection(), "Connection should not be null");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase2.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase2.java
@@ -1,0 +1,20 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockConnectionTestCase2 {
+
+    @Test
+    void createChannel_shouldReturnValidMockChannel() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        assertNotNull(connection, "Connection should not be null");
+
+        MockChannel channel = (MockChannel) connection.createChannel();
+        assertNotNull(channel, "Channel should not be null");
+        assertTrue(channel instanceof MockChannel, "Should be instance of MockChannel");
+    }
+}
+

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase8.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTestCase8.java
@@ -1,0 +1,31 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MockConnectionTestCase8 {
+
+    @Test
+    void multipleChannelsFromOneConnection_shouldOperateIndependently() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+
+        // Create two channels from the same connection
+        MockChannel channel1 = (MockChannel) connection.createChannel();
+        MockChannel channel2 = (MockChannel) connection.createChannel();
+
+        String queue1 = "channel1-queue";
+        String queue2 = "channel2-queue";
+
+        // Declare queues on both channels
+        channel1.queueDeclare(queue1, false, false, false, null);
+        channel2.queueDeclare(queue2, false, false, false, null);
+
+        // Publish messages on both queues via different channels
+        assertDoesNotThrow(() -> {
+            channel1.basicPublish("", queue1, null, "Message from channel 1".getBytes());
+            channel2.basicPublish("", queue2, null, "Message from channel 2".getBytes());
+        }, "Both channels should operate independently without exception");
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/mockChannelTestCase6.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/mockChannelTestCase6.java
@@ -1,0 +1,22 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class mockChannelTestCase6 {
+
+    @Test
+    void basicPublish_toUndeclaredQueue_shouldNotCrash() throws Exception {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        MockConnection connection = (MockConnection) factory.newConnection();
+        MockChannel channel = (MockChannel) connection.createChannel();
+
+        String queueName = "non-existent-queue";
+
+        // Assert that publishing to undeclared queue does not throw
+        assertDoesNotThrow(() -> {
+            channel.basicPublish("", queueName, null, "Silent publish".getBytes());
+        }, "Publishing to undeclared queue should not crash (mock behavior)");
+    }
+}


### PR DESCRIPTION
**Test Target:** MockChannel  
**What is being tested:** Attempt to re-declare an existing queue with different properties  
**Technique Used:** Conflict Handling + Boundary Case  
**Expected Result:** In this mock setup, re-declaring does not throw (verified behavior)  
**Actual Result:** Test passed successfully — re-declaring the queue with conflicting flags did not raise any exception, confirming mock behavior.
